### PR TITLE
Mikan認証設定画面で既存の設定値が取得できない問題を修正

### DIFF
--- a/src/client/js/services/AdminMikanSecurityContainer.js
+++ b/src/client/js/services/AdminMikanSecurityContainer.js
@@ -20,7 +20,7 @@ export default class AdminMikanSecurityContainer extends Container {
 
     this.state = {
       retrieveError: null,
-      mikanApiUrl: '',
+      mikanApiUrl: this.dummyApiUrl,
       mikanLoginUrl: '',
       mikanCookieName: '',
       isSameUsernameTreatedAsIdenticalUser: false,


### PR DESCRIPTION
`MikanSecuritySetting.jsx` 内で、取得する必要があるかの判定を
`adminMikanSecurityContainer.state.apiUrl === adminMikanSecurityContainer.dummyApiUrl`
で行っているため、初期値を`dummyApiUrl`にする必要がある。